### PR TITLE
Remove https from urls

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Redirecting…</title>
   <!-- Meta refresh as primary redirect -->
-  <meta http-equiv="refresh" content="2;url=https://QamDas-QamDa-MNUr4LimPg1j-799617981.us-west-2.elb.amazonaws.com/">
+  <meta http-equiv="refresh" content="2;url=http://QamDas-QamDa-MNUr4LimPg1j-799617981.us-west-2.elb.amazonaws.com/">
   <style>
     html, body { height: 100%; margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; color: #111; background: #f8fafc; }
     .container { display: flex; align-items: center; justify-content: center; height: 100%; }
@@ -19,7 +19,7 @@
   <script>
     // JavaScript fallback to ensure redirect happens even if meta refresh is blocked
     (function() {
-      var targetUrl = "https://QamDas-QamDa-MNUr4LimPg1j-799617981.us-west-2.elb.amazonaws.com/";
+      var targetUrl = "http://QamDas-QamDa-MNUr4LimPg1j-799617981.us-west-2.elb.amazonaws.com/";
       setTimeout(function() { window.location.replace(targetUrl); }, 2000);
     })();
   </script>
@@ -30,7 +30,7 @@
     <div class="card">
       <p class="title">Redirecting you…</p>
       <p class="desc">You will be redirected in 2 seconds to our load balancer.</p>
-      <a class="link" href="https://QamDas-QamDa-MNUr4LimPg1j-799617981.us-west-2.elb.amazonaws.com/">Go now</a>
+      <a class="link" href="http://QamDas-QamDa-MNUr4LimPg1j-799617981.us-west-2.elb.amazonaws.com/">Go now</a>
       <p class="small">If nothing happens, click the link above.</p>
     </div>
   </div>


### PR DESCRIPTION
Update `index.html` to use `http://` for all redirect URLs as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-08531101-68ee-4b51-b975-b40f91aa8400">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-08531101-68ee-4b51-b975-b40f91aa8400">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

